### PR TITLE
Update tableify.go

### DIFF
--- a/tableify.go
+++ b/tableify.go
@@ -78,7 +78,9 @@ func (t *Table) SetHeadersFromStruct(obj interface{}) {
 					width = 0
 				} else {
 					width, err = strconv.Atoi(parts[1])
-					panic(fmt.Errorf("width is not an integer: %s", parts[1], err.Error()))
+					if err != nil{
+						panic(fmt.Errorf("width is not an integer: %s", parts[1], err.Error()))
+					}
 				}
 
 				// 2: format


### PR DESCRIPTION
strconv.Atoi 将字符串转成整数，当转换成功时，err是nil，所以下面的这行
`panic(fmt.Errorf("width is not an integer: %s", parts[1], err.Error())) `
会访问空指针，程序会出错